### PR TITLE
fixed expense price when no quantity is given

### DIFF
--- a/invoice-manager-app/src/app/components/invoice-template/invoice-template.component.html
+++ b/invoice-manager-app/src/app/components/invoice-template/invoice-template.component.html
@@ -36,7 +36,14 @@
         <td>{{ expense.description }}</td>
         <td>{{ expense.quantity }}</td>
         <td>€ {{ expense.unitPrice }}</td>
-        <td>€ {{ expense.unitPrice * expense.quantity }}</td>
+        <td>
+          €
+          {{
+            expense.quantity
+              ? expense.unitPrice * expense.quantity
+              : expense.unitPrice
+          }}
+        </td>
       </tr>
       <tr class="vertical-fill"></tr>
       <tr class="border-top">


### PR DESCRIPTION
Fixed expenses costing €0 when only the unit price is given and no quantity. Now the unit price is shown as the total if there is no quantity.